### PR TITLE
Propose adding the OSI approved licence badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 <!-- SPDX-FileCopyrightText: 2019 The LumoSQL Authors -->
-
+<a href="https://opensource.org"><img height="150" align="left" src="https://opensource.org/files/OSIApprovedCropped.png" alt="Open Source Initiative Approved License logo"></a>
 # LumoSQL
 
 ## About LumoSQL


### PR DESCRIPTION
Tweet from Kevin P Flemming pointed out that there are so far only 23 git repos that show they use an OSI approved license.  This is one way of demonstrating why LumoSQL exists to service potential users who wish to use LightSQL but can't because they want to use Open Source Code.  

https://twitter.com/realkpfleming/status/1246459210184953865?s=20